### PR TITLE
Eobs 281, 282, 568, and 569

### DIFF
--- a/nh_odoo_fixes/__init__.py
+++ b/nh_odoo_fixes/__init__.py
@@ -5,4 +5,5 @@ from . import fix_odoo8_fields_many2many_set
 from . import fix_read_group_fill_results
 from . import fix_server_shutdown_issue
 from . import orm_fixes
+from . import validate
 from .tests import common

--- a/nh_odoo_fixes/__init__.py
+++ b/nh_odoo_fixes/__init__.py
@@ -5,5 +5,7 @@ from . import fix_odoo8_fields_many2many_set
 from . import fix_read_group_fill_results
 from . import fix_server_shutdown_issue
 from . import orm_fixes
+from . import remove_exception_name_from_error_dialogs
 from . import validate
+
 from .tests import common

--- a/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
+++ b/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
@@ -1,9 +1,10 @@
 from openerp.osv.orm import except_orm
 
+old_init = except_orm.__init__
 
 def new_init(self, name, value):
-    self.name = name
-    self.value = value
+    global old_init
+    old_init(self, name, value)
     # Tried `value` and `(value)` but these resulted in each character being
     # interpreted as an arg and for some reason only the first two args are
     # displayed in the error message client side.

--- a/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
+++ b/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
@@ -2,6 +2,7 @@ from openerp.osv.orm import except_orm
 
 
 def new_init(self, name, value):
+    self.name = name
     self.value = value
     # Tried `value` and `(value)` but these resulted in each character being
     # interpreted as an arg and for some reason only the first two args are
@@ -9,7 +10,6 @@ def new_init(self, name, value):
     #
     # Also tried `(value,)` and `(value,None)` but these second args resulted
     # in `undefined` and `null` respectively being displayed client side.
-    self.args = (value,'')
+    self.args = (value, '')
 
 except_orm.__init__ = new_init
-

--- a/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
+++ b/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
@@ -1,0 +1,15 @@
+from openerp.osv.orm import except_orm
+
+
+def new_init(self, name, value):
+    self.value = value
+    # Tried `value` and `(value)` but these resulted in each character being
+    # interpreted as an arg and for some reason only the first two args are
+    # displayed in the error message client side.
+    #
+    # Also tried `(value,)` and `(value,None)` but these second args resulted
+    # in `undefined` and `null` respectively being displayed client side.
+    self.args = (value,'')
+
+except_orm.__init__ = new_init
+

--- a/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
+++ b/nh_odoo_fixes/remove_exception_name_from_error_dialogs.py
@@ -2,6 +2,7 @@ from openerp.osv.orm import except_orm
 
 old_init = except_orm.__init__
 
+
 def new_init(self, name, value):
     global old_init
     old_init(self, name, value)

--- a/nh_odoo_fixes/tests/__init__.py
+++ b/nh_odoo_fixes/tests/__init__.py
@@ -4,4 +4,4 @@ from . import test_cookie_fix
 from . import test_orm_fixes
 from . import test_fix_odoo8_fields_many2many
 from . import test_fix_read_group_fill_results
-from .validate import test_not_in_the_future
+from .validate import *

--- a/nh_odoo_fixes/tests/__init__.py
+++ b/nh_odoo_fixes/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_cookie_fix
 from . import test_orm_fixes
 from . import test_fix_odoo8_fields_many2many
 from . import test_fix_read_group_fill_results
+from .validate import test_not_in_the_future

--- a/nh_odoo_fixes/tests/validate/__init__.py
+++ b/nh_odoo_fixes/tests/validate/__init__.py
@@ -1,0 +1,2 @@
+from . import test_not_in_the_future
+from . import test_start_datetime_not_after_end_datetime

--- a/nh_odoo_fixes/tests/validate/test_not_in_the_future.py
+++ b/nh_odoo_fixes/tests/validate/test_not_in_the_future.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+
+from openerp.addons.nh_odoo_fixes import validate
+from openerp.exceptions import ValidationError
+from openerp.tests.common import TransactionCase
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT as DTF
+
+
+class TestNotInTheFuture(TransactionCase):
+    """
+    Tests the :method:`validate.not_in_the_future` method.
+    """
+    def test_now_does_not_raise_exception_with_datetime(self):
+        validate.not_in_the_future(datetime.now())
+
+    def test_now_does_not_raise_exception_with_string(self):
+        validate.not_in_the_future(datetime.now().strftime(DTF))
+
+    def test_one_second_in_the_future_does_raise_exception_with_datetime(self):
+        with self.assertRaises(ValidationError):
+            validate.not_in_the_future(datetime.now() + timedelta(seconds=1))
+
+    def test_one_second_in_the_future_does_raise_exception_with_string(self):
+        with self.assertRaises(ValidationError):
+            date_time = (datetime.now() + timedelta(seconds=1)).strftime(DTF)
+            validate.not_in_the_future(date_time)
+
+    def test_before_1900_with_datetime_does_not_raise_exception(self):
+        validate.not_in_the_future(datetime(year=1899, month=6, day=6))
+
+    def test_before_1900_with_string_raises_exception(self):
+        with self.assertRaises(ValueError):
+            date_time = datetime(year=1899, month=6, day=6).strftime(DTF)
+            validate.not_in_the_future(date_time)
+
+    def test_passing_none(self):
+        with self.assertRaises(TypeError):
+            validate.not_in_the_future(None)
+
+    def test_passing_false(self):
+        with self.assertRaises(TypeError):
+            validate.not_in_the_future(False)
+
+    def test_string_not_in_correct_date_format(self):
+        with self.assertRaises(ValueError):
+            validate.not_in_the_future('Narnteenth uv Septembah')

--- a/nh_odoo_fixes/tests/validate/test_start_datetime_not_after_end_datetime.py
+++ b/nh_odoo_fixes/tests/validate/test_start_datetime_not_after_end_datetime.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+
+from openerp.exceptions import ValidationError
+from openerp.tests.common import TransactionCase
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT as DTF
+
+from openerp.addons.nh_odoo_fixes import validate
+
+
+class TestStartDatetimeNotAfterEndDatetime(TransactionCase):
+    """
+    Tests the :method:`validate.start_datetime_not_after_end_datetime` method.
+    """
+    @staticmethod
+    def now():
+        return datetime.now()
+
+    @staticmethod
+    def one_second_ago():
+        return datetime.now() - timedelta(seconds=1)
+
+    def test_start_datetime_before_end_datetime_does_not_raise_exception(self):
+        start_datetime = self.one_second_ago()
+        end_datetime = self.now()
+        validate.start_datetime_not_after_end_datetime(
+            start_datetime, end_datetime
+        )
+
+    def test_start_before_end_with_strings(self):
+        start_datetime_string = self.one_second_ago().strftime(DTF)
+        end_datetime_string = self.now().strftime(DTF)
+        validate.start_datetime_not_after_end_datetime(
+            start_datetime_string,
+            end_datetime_string
+        )
+
+    def test_end_datetime_before_start_datetime_raises_exception(self):
+        with self.assertRaises(ValidationError):
+            start_datetime = self.now()
+            end_datetime = self.one_second_ago()
+            validate.start_datetime_not_after_end_datetime(
+                start_datetime,
+                end_datetime
+            )
+
+    def test_equal_start_and_end_date_does_not_raise_exception(self):
+        start_datetime = self.one_second_ago()
+        end_datetime = self.one_second_ago()
+        validate.start_datetime_not_after_end_datetime(
+            start_datetime,
+            end_datetime
+        )
+
+    def test_before_1900_with_datetime_does_not_raise_exception(self):
+        start_datetime = datetime(year=1899, month=6, day=6)
+        end_datetime = datetime(year=1899, month=6, day=7)
+        validate.start_datetime_not_after_end_datetime(
+            start_datetime, end_datetime
+        )
+
+    def test_before_1900_with_string_raises_exception(self):
+        with self.assertRaises(ValueError):
+            start_datetime_string = \
+                datetime(year=1899, month=6, day=6).strftime(DTF)
+            end_datetime_string = \
+                datetime(year=1899, month=6, day=7).strftime(DTF)
+            validate.start_datetime_not_after_end_datetime(
+                start_datetime_string, end_datetime_string
+            )
+
+    def test_passing_none(self):
+        with self.assertRaises(TypeError):
+            validate.start_datetime_not_after_end_datetime(None)
+
+    def test_passing_false(self):
+        with self.assertRaises(TypeError):
+            validate.start_datetime_not_after_end_datetime(False)
+
+    def test_string_not_in_correct_date_format(self):
+        with self.assertRaises(ValueError):
+            bad_format = 'Narnteenth uv Septembah'
+            validate.start_datetime_not_after_end_datetime(
+                bad_format, bad_format
+            )

--- a/nh_odoo_fixes/validate.py
+++ b/nh_odoo_fixes/validate.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+A place for generic validation functions.
+
+In some places the variable name `date_time` has been used to avoid conflict
+with the imported `datetime` class.
+"""
 from datetime import datetime
 
 from openerp.exceptions import ValidationError
@@ -12,6 +18,22 @@ def not_in_the_future_multiple_args(*args):
 
 
 def not_in_the_future(date_time):
+    date_time = _convert_string_to_datetime(date_time)
+
+    now = datetime.now()
+    if date_time > now:
+        raise ValidationError("Date cannot be in the future.")
+
+
+def start_datetime_not_after_end_datetime(start_datetime, end_datetime):
+    start_datetime = _convert_string_to_datetime(start_datetime)
+    end_datetime = _convert_string_to_datetime(end_datetime)
+
+    if start_datetime > end_datetime:
+        raise ValidationError("The start date cannot be after the end date.")
+
+
+def _convert_string_to_datetime(date_time):
     if isinstance(date_time, basestring):
         date_time = datetime.strptime(date_time, DTF)
     elif isinstance(date_time, datetime):
@@ -20,7 +42,4 @@ def not_in_the_future(date_time):
         raise TypeError("This function only accepts str or datetime objects. "
                         "{invalid_type} is not a valid type."
                         .format(invalid_type=type(date_time)))
-
-    now = datetime.now()
-    if date_time > now:
-        raise ValidationError("Date cannot be in the future.")
+    return date_time

--- a/nh_odoo_fixes/validate.py
+++ b/nh_odoo_fixes/validate.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from openerp.exceptions import ValidationError
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT as DTF
+
+
+def not_in_the_future_multiple_args(*args):
+    for arg in args:
+        if arg:
+            not_in_the_future(arg)
+
+
+def not_in_the_future(date_time):
+    if isinstance(date_time, basestring):
+        date_time = datetime.strptime(date_time, DTF)
+    elif isinstance(date_time, datetime):
+        pass
+    else:
+        raise TypeError("This function only accepts str or datetime objects. "
+                        "{invalid_type} is not a valid type."
+                        .format(invalid_type=type(date_time)))
+
+    now = datetime.now()
+    if date_time > now:
+        raise ValidationError("Date cannot be in the future.")


### PR DESCRIPTION
* Print report validation to prevent dates in the future.
* Print report validation to prevent start dates after end dates.
* Error dialogs generated from the exceptions being raised server side no longer display the name of the exception. This applies to all such error dialogs in the system.