### PR TITLE
Fixed test failing in Travis.

### DIFF
--- a/nh_clinical/tests/common/nh_clinical_test_utils.py
+++ b/nh_clinical/tests/common/nh_clinical_test_utils.py
@@ -21,7 +21,6 @@ class NhClinicalTestUtils(AbstractModel):
         self.spell_model = self.env['nh.clinical.spell']
         self.activity_model = self.env['nh.activity']
         self.activity_pool = self.pool['nh.activity']
-        self.ews_model = self.env['nh.clinical.patient.observation.ews']
         # nh.eobs.api not available to this module
         self.api_model = self.env['nh.clinical.api']
 


### PR DESCRIPTION
Removed model reference that was causing failures in some cases. EWS is a child module of `nh_clinical` and so it not known by tests run lower down in the inheritance tree.