### PR TITLE
EOBS-1521 discharge required location

### DIFF
--- a/nh_clinical/models/adt/patient_discharge.py
+++ b/nh_clinical/models/adt/patient_discharge.py
@@ -61,11 +61,11 @@ class nh_clinical_adt_patient_discharge(orm.Model):
         activity_pool = self.pool['nh.activity']
         spell_id = spell_pool.get_by_patient_id(
             cr, uid, patient_id.id, context=context)
-        if not vals.get('location'):
-            raise osv.except_osv(
-                'Discharge Error!',
-                'Missing location!')
         if not spell_id:
+            if not vals.get('location'):
+                raise osv.except_osv(
+                    'Discharge Error!',
+                    'Missing location and patient is not admitted!')
             discharged = activity_pool.search(
                 cr, uid,
                 [
@@ -78,10 +78,6 @@ class nh_clinical_adt_patient_discharge(orm.Model):
                     'Discharge Error!',
                     'Patient is already discharged!'
                 )
-            # else:
-            #     raise osv.except_osv(
-            #         'Discharge Error!',
-            #         'Patient is not admitted!')
             _logger.warn("Patient admitted from a discharge call!")
             location_pool = self.pool['nh.clinical.location']
             location_id = location_pool.get_by_code(


### PR DESCRIPTION
Fixing issue where discharge required a location when it only needs a location if you are trying to discharge a patient who doesn't have a spell but is not already discharged.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Code review conducted (request a review by assigning a *reviewer* on the right-hand side).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.