### PR TITLE
Removing patient from location on cancelling admission

### DIFF
--- a/nh_clinical/models/adt/cancel_admit.py
+++ b/nh_clinical/models/adt/cancel_admit.py
@@ -47,6 +47,10 @@ class nh_clinical_adt_patient_cancel_admit(orm.Model):
         spell_id = spell_pool.get_by_patient_id(
             cr, uid, patient_id.id, exception='False', context=context)
         spell = spell_pool.browse(cr, uid, spell_id, context=context)
+        if patient_id.current_location_id:
+            patient_pool.write(cr, uid, patient_id.id, {
+                'current_location_id': None
+            })
         activity_pool.write(
             cr, uid, activity_id,
             {

--- a/nh_clinical/tests/nh_clinical_adt/test_adt_patient_cancel_admit.py
+++ b/nh_clinical/tests/nh_clinical_adt/test_adt_patient_cancel_admit.py
@@ -84,3 +84,22 @@ class TestAdtPatientCancelAdmit(TransactionCase):
             error.exception.value,
             "Patient's Hospital Number must be supplied!"
         )
+
+    def test_removes_patient_from_bed(self):
+        """
+        Test that on cancelling the admission the patient is removed from the
+        location
+        """
+        self.test_utils.spell_activity_id = self.spell.activity_id.id
+        self.test_utils.spell_activity = self.spell.activity_id
+        self.test_utils.placement = self.test_utils.create_placement()
+        self.test_utils.place_patient()
+        self.assertEqual(
+            self.test_utils.patient.current_location_id.id,
+            self.test_utils.bed.id
+        )
+        cancel_admit_data = {'other_identifier': self.existing_hospital_number}
+        activity_id = self.cancel_model.create_activity({}, cancel_admit_data)
+        activity = self.activity_model.browse(activity_id)
+        activity.complete()
+        self.assertFalse(self.test_utils.patient.current_location_id.id)


### PR DESCRIPTION
EOBS-227. The patient wasn't being removed from the location when having their admission cancelled which meant that they stayed in the location (and this could result in a number of patients in one bed, even if the spells weren't active)

---

Before this pull request can be merged the following must be true.
- [x] Unit tests pass (Travis integration).
- [x] No code quality issues (Codacy integration).
- [ ] Code review conducted (request a review by assigning a *reviewer* on the right-hand side).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.