### PR TITLE
Add test utils refactor missing from initial EOBS-2369 development

### DIFF
--- a/nh_clinical/tests/common/nh_clinical_test_utils.py
+++ b/nh_clinical/tests/common/nh_clinical_test_utils.py
@@ -9,9 +9,12 @@ class NhClinicalTestUtils(AbstractModel):
     _name = 'nh.clinical.test_utils'
 
     # Setup methods
-    def admit_and_place_patient(self, create_placement=True):
+    def setup_ward(self):
         self.create_locations()
         self.create_users()
+
+    def admit_and_place_patient(self, create_placement=True):
+        self.setup_ward()
         self.create_patient()
         self.spell = self.admit_patient()
         self.spell_activity_id = self.spell.activity_id.id
@@ -30,6 +33,7 @@ class NhClinicalTestUtils(AbstractModel):
         self.patient = self.create_and_register_patient()
         self.patient_id = self.patient.id
         self.hospital_number = self.patient.other_identifier
+        return self.patient
 
     def admit_patient(
             self, hospital_number=None, patient_id=None, location_code=None):


### PR DESCRIPTION
I somehow forgot to commit the *EOBS-2639* branch on *nhclinical* which contained a minor test utils refactor that was used in tests in the corresponding branch on *openeobs*.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.